### PR TITLE
PC表示時において、両幅に余白を持たせたカード幅の設定

### DIFF
--- a/src/Components/repositoryCard.tsx
+++ b/src/Components/repositoryCard.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function RepositoryCard({ repository }: Props) {
   return (
-    <div className='p-4 w-full lg:w-3/4 xl:w-3/5'>
+    <div className='p-4'>
       <div className='h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden'>
         <div className='p-4'>
           <div className='flex mb-4 md:flex-row lg:text-7xl font-bold text-slate-500'>

--- a/src/Components/repositoryCard.tsx
+++ b/src/Components/repositoryCard.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function RepositoryCard({ repository }: Props) {
   return (
-    <div className='p-4'>
+    <div className='p-4 w-full lg:w-3/4 xl:w-3/5'>
       <div className='h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden'>
         <div className='p-4'>
           <div className='flex mb-4 md:flex-row lg:text-7xl font-bold text-slate-500'>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,7 @@ export default function Home({ repositories, language, sort }: Props) {
         <div className='flex justify-end mr-8'>
           <RepositorySearchForm language={language} sort={sort} />
         </div>
-        <div className='p-4 justify-center'>
+        <div className='flex flex-wrap p-4 justify-center'>
           {repositories.length > 0 ? (
             repositories.map((repository) => (
               <RepositoryCard key={repository.id} repository={repository} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,7 @@ export default function Home({ repositories, language, sort }: Props) {
         <div className='flex justify-end mr-8'>
           <RepositorySearchForm language={language} sort={sort} />
         </div>
-        <div className='flex flex-wrap p-4 justify-center'>
+        <div className='p-4 justify-center'>
           {repositories.length > 0 ? (
             repositories.map((repository) => (
               <RepositoryCard key={repository.id} repository={repository} />


### PR DESCRIPTION
rel #5

PC表示時、カードの幅に余白を持たせる変更を加えています。
|画面幅|カード幅|
|-----|--------|
|～1023px|100%|
|1024px～1279px|75%|
|1280px～|60%|

モバイル、タブレット表示はブラウザのレスポンシブモードで確認しています。  

## モバイル表示 (390x844px)
<img width="320px" src="https://github.com/ysknsid25/booby/assets/5682821/6b4a41dc-8b2e-4ad4-8405-34fdea022377">

## タブレット表示 (834x1194px)
### 縦向き
<img width="320px" src="https://github.com/ysknsid25/booby/assets/5682821/24d99ac9-f7c2-4373-83e3-3d7f710b18f3">

### 横向き
<img width="640px" src="https://github.com/ysknsid25/booby/assets/5682821/f0060de8-7b98-4383-9502-1f5d07cc29d8">
