### PR TITLE
ページング処理を追加

### DIFF
--- a/src/Components/__test__/pagination.test.tsx
+++ b/src/Components/__test__/pagination.test.tsx
@@ -1,34 +1,40 @@
-import { fireEvent, getAllByRole, getByRole, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Pagination from '../pagination'
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn().mockReturnValue({
     pathname: '/',
-    query: {language: 'javascript'},
+    query: { language: 'javascript' },
   }),
 }))
 
 describe('Paginationのテスト', () => {
   test('Paginationのページ数が6以下の場合にlinkの数がページと同じように表示されているかどうか', () => {
-    const totalCount = 100;
-    const perPage = 50;
-    const totalPage = Math.ceil(totalCount / perPage); // 2
-    const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    const totalCount = 100
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 2
+    const { getAllByRole } = render(
+      <Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />,
+    )
     expect(getAllByRole('link')).toHaveLength(totalPage)
   })
   test('Paginationのページ数が7以上の場合に「...」が表示されているかどうか', () => {
     const totalCount = 350
     const perPage = 50
     const totalPage = Math.ceil(totalCount / perPage) // 7
-    const { getByText } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    const { getByText } = render(
+      <Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />,
+    )
     expect(getByText('...')).toBeInTheDocument()
   })
   test('Paginationのページ数が7以上の場合にlinkの数が5つ表示されているかどうか', () => {
     const totalCount = 301
     const perPage = 50
     const totalPage = Math.ceil(totalCount / perPage) // 7
-    const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    const { getAllByRole } = render(
+      <Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />,
+    )
     expect(getAllByRole('link')).toHaveLength(5)
   })
   test('PaginationのtotalCountが1000を超える場合は1000を超えるアイテムが表示されるページへの遷移をしないようにする', () => {
@@ -40,12 +46,14 @@ describe('Paginationのテスト', () => {
     const links = getAllByRole('link')
     const lastLink = links[links.length - 1]
     expect(lastLink.textContent).toBe('20')
-    expect(queryByText('21')).toBeNull();
+    expect(queryByText('21')).toBeNull()
   })
   test('Paginationの現在のページのボタンがアクティブ表記されているか', () => {
     const totalCount = 500
     const perPage = 50
-    const { getByText } = render(<Pagination currentPage={2} totalCount={totalCount} perPage={perPage} />)
+    const { getByText } = render(
+      <Pagination currentPage={2} totalCount={totalCount} perPage={perPage} />,
+    )
     const activePageLink = getByText('2')
     expect(activePageLink).toHaveClass('bg-indigo-600')
   })

--- a/src/Components/__test__/pagination.test.tsx
+++ b/src/Components/__test__/pagination.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, getAllByRole, getByRole, render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Pagination from '../pagination'
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    pathname: '/',
+    query: {language: 'javascript'},
+  }),
+}))
+
+describe('Paginationのテスト', () => {
+  test('Paginationのページ数が5以下の場合にlinkの数がページと同じように表示されているかどうか', () => {
+    const totalCount = 100;
+    const perPage = 50;
+    const totalPage = Math.ceil(totalCount / perPage); // 2
+    const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    expect(getAllByRole('link')).toHaveLength(totalPage)
+  })
+  test('Paginationのページ数が6以上の場合に「...」が表示されているかどうか', () => {
+    const totalCount = 300
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 6
+    const { getByText } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    expect(getByText('...')).toBeInTheDocument()
+  })
+  test('Paginationのページ数が6以上の場合にlinkの数が4つ表示されているかどうか', () => {
+    const totalCount = 251
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 6
+    const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    expect(getAllByRole('link')).toHaveLength(4)
+  })
+  test('Paginationのページ数が6以上の場合にlinkの数が4つ表示されているかどうか', () => {
+    const totalCount = 251
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 6
+    const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    expect(getAllByRole('link')).toHaveLength(4)
+  })
+  test('PaginationのtotalCountが1000を超える場合は1000を超えるアイテムが表示されるページへの遷移をしないようにする', () => {
+    const totalCount = 2000
+    const perPage = 50
+    const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    const links = getAllByRole('link')
+    const lastLink = links[links.length - 1]
+    expect(lastLink.textContent).toBe('20')
+  })
+  test('Paginationの現在のページのボタンがアクティブ表記されているか', () => {
+    const totalCount = 500
+    const perPage = 50
+    const { getByText } = render(<Pagination currentPage={2} totalCount={totalCount} perPage={perPage} />)
+    const activePageLink = getByText('2')
+    expect(activePageLink).toHaveClass('bg-indigo-600')
+  })
+  test('Paginationのlinkが遷移するか', () => {
+    const totalCount = 500
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 10
+    const { getAllByRole } = render(
+      <Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />,
+    )
+    const links = getAllByRole('link')
+    const lastLink = links[links.length - 1]
+    expect(lastLink.textContent).toBe('10')
+    expect(lastLink).toHaveAttribute('href', '/?language=javascript&page=10')
+  })
+})

--- a/src/Components/__test__/pagination.test.tsx
+++ b/src/Components/__test__/pagination.test.tsx
@@ -10,41 +10,37 @@ jest.mock('next/router', () => ({
 }))
 
 describe('Paginationのテスト', () => {
-  test('Paginationのページ数が5以下の場合にlinkの数がページと同じように表示されているかどうか', () => {
+  test('Paginationのページ数が6以下の場合にlinkの数がページと同じように表示されているかどうか', () => {
     const totalCount = 100;
     const perPage = 50;
     const totalPage = Math.ceil(totalCount / perPage); // 2
     const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
     expect(getAllByRole('link')).toHaveLength(totalPage)
   })
-  test('Paginationのページ数が6以上の場合に「...」が表示されているかどうか', () => {
-    const totalCount = 300
+  test('Paginationのページ数が7以上の場合に「...」が表示されているかどうか', () => {
+    const totalCount = 350
     const perPage = 50
-    const totalPage = Math.ceil(totalCount / perPage) // 6
+    const totalPage = Math.ceil(totalCount / perPage) // 7
     const { getByText } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
     expect(getByText('...')).toBeInTheDocument()
   })
-  test('Paginationのページ数が6以上の場合にlinkの数が4つ表示されているかどうか', () => {
-    const totalCount = 251
+  test('Paginationのページ数が7以上の場合にlinkの数が5つ表示されているかどうか', () => {
+    const totalCount = 301
     const perPage = 50
-    const totalPage = Math.ceil(totalCount / perPage) // 6
+    const totalPage = Math.ceil(totalCount / perPage) // 7
     const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
-    expect(getAllByRole('link')).toHaveLength(4)
-  })
-  test('Paginationのページ数が6以上の場合にlinkの数が4つ表示されているかどうか', () => {
-    const totalCount = 251
-    const perPage = 50
-    const totalPage = Math.ceil(totalCount / perPage) // 6
-    const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
-    expect(getAllByRole('link')).toHaveLength(4)
+    expect(getAllByRole('link')).toHaveLength(5)
   })
   test('PaginationのtotalCountが1000を超える場合は1000を超えるアイテムが表示されるページへの遷移をしないようにする', () => {
     const totalCount = 2000
     const perPage = 50
-    const { getAllByRole } = render(<Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />)
+    const { getAllByRole, queryByText } = render(
+      <Pagination currentPage={20} totalCount={totalCount} perPage={perPage} />,
+    )
     const links = getAllByRole('link')
     const lastLink = links[links.length - 1]
     expect(lastLink.textContent).toBe('20')
+    expect(queryByText('21')).toBeNull();
   })
   test('Paginationの現在のページのボタンがアクティブ表記されているか', () => {
     const totalCount = 500
@@ -57,12 +53,10 @@ describe('Paginationのテスト', () => {
     const totalCount = 500
     const perPage = 50
     const totalPage = Math.ceil(totalCount / perPage) // 10
-    const { getAllByRole } = render(
-      <Pagination currentPage={1} totalCount={totalCount} perPage={perPage} />,
+    const { getByText } = render(
+      <Pagination currentPage={8} totalCount={totalCount} perPage={perPage} />,
     )
-    const links = getAllByRole('link')
-    const lastLink = links[links.length - 1]
-    expect(lastLink.textContent).toBe('10')
-    expect(lastLink).toHaveAttribute('href', '/?language=javascript&page=10')
+    const link = getByText('9')
+    expect(link).toHaveAttribute('href', '/?language=javascript&page=9')
   })
 })

--- a/src/Components/__test__/pagination.test.tsx
+++ b/src/Components/__test__/pagination.test.tsx
@@ -37,6 +37,48 @@ describe('Paginationのテスト', () => {
     )
     expect(getAllByRole('link')).toHaveLength(5)
   })
+  test('Paginationのページ数が7以上の場合かつ現在ページが4のときに左右に「...」が表示されているかどうか', () => {
+    const totalCount = 301
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 7
+    const { getByRole } = render(
+      <Pagination currentPage={4} totalCount={totalCount} perPage={perPage} />,
+    )
+    const pagination = getByRole('navigation')
+    const children = pagination.children
+    expect(children[0].textContent).toBe('...')
+    expect(children[children.length - 1].textContent).toBe('...')
+  })
+  test('Paginationのページ数が7以上の場合かつ現在ページが4のときにlinkの数が5つ表示されているかどうか', () => {
+    const totalCount = 301
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 7
+    const { getAllByRole } = render(
+      <Pagination currentPage={4} totalCount={totalCount} perPage={perPage} />,
+    )
+    expect(getAllByRole('link')).toHaveLength(5)
+  })
+  test('Paginationのページ数が7以上の場合かつ現在ページが最終ページの2ページ前のときに左に「...」が表示されているかどうか', () => {
+    const totalCount = 301
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 7
+    const { getByRole } = render(
+      <Pagination currentPage={totalPage - 2} totalCount={totalCount} perPage={perPage} />,
+    )
+    const pagination = getByRole('navigation')
+    const children = pagination.children
+    expect(children[0].textContent).toBe('...')
+    expect(children[children.length - 1].textContent).not.toBe('...')
+  })
+  test('Paginationのページ数が7以上の場合かつ現在ページが最終ページの2ページ前のときにlinkの数が5つ表示されているかどうか', () => {
+    const totalCount = 301
+    const perPage = 50
+    const totalPage = Math.ceil(totalCount / perPage) // 7
+    const { getAllByRole } = render(
+      <Pagination currentPage={totalPage - 2} totalCount={totalCount} perPage={perPage} />,
+    )
+    expect(getAllByRole('link')).toHaveLength(5)
+  })
   test('PaginationのtotalCountが1000を超える場合は1000を超えるアイテムが表示されるページへの遷移をしないようにする', () => {
     const totalCount = 2000
     const perPage = 50

--- a/src/Components/pagination.tsx
+++ b/src/Components/pagination.tsx
@@ -7,6 +7,13 @@ type Props = {
   perPage: number
 }
 
+/**
+ * ページ番号を表示するための配列を返す関数です。
+ *
+ * @param {number} currentPage - 現在のアクティブなページ番号です。
+ * @param {number} totalPage - 総ページ数です。
+ * @returns {Array<string | number>} - 表示するページ番号の配列です。
+ */
 function getPageNumbers(currentPage: number, totalPage: number): Array<string | number> {
   // 6ページ以下の場合は全て表示する
   if (totalPage <= 6) {

--- a/src/Components/pagination.tsx
+++ b/src/Components/pagination.tsx
@@ -42,7 +42,6 @@ function getPageNumbers(currentPage: number, totalPage: number): Array<string | 
 export default function Pagination({ currentPage, totalCount, perPage }: Props) {
   const router = useRouter()
   let totalPage = Math.ceil(totalCount / perPage)
-  // 1000件を超える場合はAPI制限でエラーになるため、1000件までの遷移先しか表示しない
   const apiMaxCount = 1000
   if (totalCount > apiMaxCount) {
     totalPage = Math.floor(apiMaxCount / perPage)

--- a/src/Components/pagination.tsx
+++ b/src/Components/pagination.tsx
@@ -35,9 +35,10 @@ function getPageNumbers(currentPage: number, totalPage: number): Array<string | 
 export default function Pagination({ currentPage, totalCount, perPage }: Props) {
   const router = useRouter()
   let totalPage = Math.ceil(totalCount / perPage)
-  // 1000件以上はAPI制限でエラーになるため、1000件までの遷移先しか表示しない
-  if (totalCount > 1000) {
-    totalPage = Math.floor(1000 / perPage)
+  // 1000件を超える場合はAPI制限でエラーになるため、1000件までの遷移先しか表示しない
+  const apiMaxCount = 1000
+  if (totalCount > apiMaxCount) {
+    totalPage = Math.floor(apiMaxCount / perPage)
   }
   let pageNumbers: Array<string | number> = getPageNumbers(currentPage, totalPage)
   return (

--- a/src/Components/pagination.tsx
+++ b/src/Components/pagination.tsx
@@ -7,6 +7,23 @@ type Props = {
   perPage: number
 }
 
+function getPageNumbers(currentPage: number, totalPage: number): Array<string | number> {
+  // 6ページ以下の場合は全て表示する
+  if (totalPage <= 6) {
+    return Array.from({ length: totalPage }, (_, index) => index + 1)
+  }
+
+  if(currentPage <= 3) {
+    return [1, 2, 3, 4, 5, '...']
+  }
+
+  if(currentPage >= totalPage - 2) {
+    return ['...', totalPage - 4, totalPage - 3, totalPage - 2, totalPage - 1, totalPage]
+  }
+
+  return ['...', currentPage - 2, currentPage - 1, currentPage, currentPage + 1, currentPage + 2, '...']
+}
+
 export default function Pagination({ currentPage, totalCount, perPage }: Props) {
   const router = useRouter()
   let totalPage = Math.ceil(totalCount / perPage)
@@ -14,21 +31,15 @@ export default function Pagination({ currentPage, totalCount, perPage }: Props) 
   if (totalCount > 1000) {
     totalPage = Math.floor(1000 / perPage)
   }
-  // 5ページ以下の場合は全て表示する
-  let pageNumbers: Array<string | number> = []
-  if (totalPage <= 5) {
-    pageNumbers = Array.from({ length: totalPage }, (_, index) => index + 1)
-  } else {
-    pageNumbers = [1, 2, '...', totalPage - 1, totalPage]
-  }
+  let pageNumbers: Array<string | number> = getPageNumbers(currentPage, totalPage)
   return (
     <div className='flex items-center justify-center bg-white px-4 py-3 sm:px-6'>
       <nav className='inline-flex gap-x-1.5' aria-label='Pagination'>
-        {pageNumbers.map((pageNumber) => {
+        {pageNumbers.map((pageNumber, i) => {
           if (pageNumber === '...') {
             return (
               <span
-                key={pageNumber}
+                key={i}
                 className='w-10 h-10 rounded-full inline-flex items-center text-lg justify-center'
               >
                 ...
@@ -38,7 +49,7 @@ export default function Pagination({ currentPage, totalCount, perPage }: Props) 
           if (pageNumber === currentPage) {
             return (
               <Link
-                key={pageNumber}
+                key={i}
                 href={{ pathname: router.pathname, query: { ...router.query, page: pageNumber } }}
                 className='w-10 h-10 rounded-full inline-flex items-center justify-center bg-indigo-600 text-sm font-semibold text-white'
               >
@@ -48,7 +59,7 @@ export default function Pagination({ currentPage, totalCount, perPage }: Props) 
           }
           return (
             <Link
-              key={pageNumber}
+              key={i}
               href={{ pathname: router.pathname, query: { ...router.query, page: pageNumber } }}
               className='w-10 h-10 rounded-full inline-flex items-center justify-center ring-1 ring-inset ring-gray-300 text-sm'
             >

--- a/src/Components/pagination.tsx
+++ b/src/Components/pagination.tsx
@@ -13,15 +13,23 @@ function getPageNumbers(currentPage: number, totalPage: number): Array<string | 
     return Array.from({ length: totalPage }, (_, index) => index + 1)
   }
 
-  if(currentPage <= 3) {
+  if (currentPage <= 3) {
     return [1, 2, 3, 4, 5, '...']
   }
 
-  if(currentPage >= totalPage - 2) {
+  if (currentPage >= totalPage - 2) {
     return ['...', totalPage - 4, totalPage - 3, totalPage - 2, totalPage - 1, totalPage]
   }
 
-  return ['...', currentPage - 2, currentPage - 1, currentPage, currentPage + 1, currentPage + 2, '...']
+  return [
+    '...',
+    currentPage - 2,
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    currentPage + 2,
+    '...',
+  ]
 }
 
 export default function Pagination({ currentPage, totalCount, perPage }: Props) {

--- a/src/Components/pagination.tsx
+++ b/src/Components/pagination.tsx
@@ -29,7 +29,7 @@ export default function Pagination({ currentPage, totalCount, perPage }: Props) 
             return (
               <span
                 key={pageNumber}
-                className='w-10 h-10 rounded-full inline-flex items-center justify-center ring-1 ring-inset ring-gray-300'
+                className='w-10 h-10 rounded-full inline-flex items-center text-lg justify-center'
               >
                 ...
               </span>

--- a/src/Components/pagination.tsx
+++ b/src/Components/pagination.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+type Props = {
+  currentPage: number
+  totalCount: number
+  perPage: number
+}
+
+export default function Pagination({ currentPage, totalCount, perPage }: Props) {
+  const router = useRouter()
+  let totalPage = Math.ceil(totalCount / perPage)
+  // 1000件以上はAPI制限でエラーになるため、1000件までの遷移先しか表示しない
+  if (totalCount > 1000) {
+    totalPage = Math.floor(1000 / perPage)
+  }
+  // 5ページ以下の場合は全て表示する
+  let pageNumbers: Array<string | number> = []
+  if (totalPage <= 5) {
+    pageNumbers = Array.from({ length: totalPage }, (_, index) => index + 1)
+  } else {
+    pageNumbers = [1, 2, '...', totalPage - 1, totalPage]
+  }
+  return (
+    <div className='flex items-center justify-center bg-white px-4 py-3 sm:px-6'>
+      <nav className='inline-flex gap-x-1.5' aria-label='Pagination'>
+        {pageNumbers.map((pageNumber) => {
+          if (pageNumber === '...') {
+            return (
+              <span
+                key={pageNumber}
+                className='w-10 h-10 rounded-full inline-flex items-center justify-center ring-1 ring-inset ring-gray-300'
+              >
+                ...
+              </span>
+            )
+          }
+          if (pageNumber === currentPage) {
+            return (
+              <Link
+                key={pageNumber}
+                href={{ pathname: router.pathname, query: { ...router.query, page: pageNumber } }}
+                className='w-10 h-10 rounded-full inline-flex items-center justify-center bg-indigo-600 text-sm font-semibold text-white'
+              >
+                {pageNumber}
+              </Link>
+            )
+          }
+          return (
+            <Link
+              key={pageNumber}
+              href={{ pathname: router.pathname, query: { ...router.query, page: pageNumber } }}
+              className='w-10 h-10 rounded-full inline-flex items-center justify-center ring-1 ring-inset ring-gray-300 text-sm'
+            >
+              {pageNumber}
+            </Link>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}

--- a/src/pages/api/githubApi.ts
+++ b/src/pages/api/githubApi.ts
@@ -2,7 +2,8 @@ import { Octokit } from 'octokit'
 
 export type GitHubRepositorySearch = {
   language: string
-  sort?: 'stars' | 'forks' | 'help-wanted-issues' | 'updated'
+  sort: 'stars' | 'forks' | 'help-wanted-issues' | 'updated'
+  page: number
 }
 
 export type GitHubRepository = {
@@ -28,7 +29,7 @@ export const getRepositories = async (
     sort: searchCondition.sort,
     order: 'desc',
     per_page: 50,
-    page: 1,
+    page: searchCondition.page,
   })
   if (response.data.items) {
     const repositories: GitHubRepository[] = response.data.items.map((item) => {

--- a/src/pages/api/githubApi.ts
+++ b/src/pages/api/githubApi.ts
@@ -4,6 +4,7 @@ export type GitHubRepositorySearch = {
   language: string
   sort: 'stars' | 'forks' | 'help-wanted-issues' | 'updated'
   page: number
+  perPage: number
 }
 
 export type GitHubRepository = {
@@ -31,7 +32,7 @@ export const getRepositories = async (
     q: `stars:>100+good-first-issues:>1+language:${searchCondition.language}`,
     sort: searchCondition.sort,
     order: 'desc',
-    per_page: 50,
+    per_page: searchCondition.perPage,
     page: searchCondition.page,
   })
   if (response.data.items) {

--- a/src/pages/api/githubApi.ts
+++ b/src/pages/api/githubApi.ts
@@ -23,7 +23,10 @@ const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
 // GitHubのリポジトリを取得する
 export const getRepositories = async (
   searchCondition: GitHubRepositorySearch,
-): Promise<GitHubRepository[]> => {
+): Promise<{
+  totalCount: number
+  repositories: GitHubRepository[]
+}> => {
   const response = await octokit.rest.search.repos({
     q: `stars:>100+good-first-issues:>1+language:${searchCondition.language}`,
     sort: searchCondition.sort,
@@ -44,7 +47,7 @@ export const getRepositories = async (
         forksCount: item.forks_count,
       }
     })
-    return repositories
+    return { totalCount: response.data.total_count, repositories }
   }
-  return []
+  return { totalCount: 0, repositories: [] }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,9 +16,10 @@ type Props = {
   sort: string
   page: number
   totalCount: number
+  perPage: number
 }
 
-export default function Home({ repositories, language, sort, page, totalCount }: Props) {
+export default function Home({ repositories, language, sort, page, totalCount, perPage }: Props) {
   return (
     <>
       <HeadComp />
@@ -36,7 +37,7 @@ export default function Home({ repositories, language, sort, page, totalCount }:
             <h1>NO Data or API Error. Please wait </h1>
           )}
         </div>
-        <Pagination currentPage={page} totalCount={totalCount} perPage={50} />
+        <Pagination currentPage={page} totalCount={totalCount} perPage={perPage} />
       </main>
     </>
   )
@@ -47,10 +48,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     language: 'javascript',
     sort: 'stars',
     page: 1,
+    perPage: 50
   }
   let language = 'javascript'
   let sort: SortOption['value'] = 'stars'
   let page = 1
+  let perPage = 50
   if (Object.keys(context.query).length > 0) {
     if (context.query.language !== '' && typeof context.query.language == 'string') {
       searchCondition.language = context.query.language
@@ -69,6 +72,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       }
       searchCondition.page = page
     }
+    if(context.query.per_page !== '' && typeof context.query.per_page == 'string') {
+      perPage = Number(context.query.per_page)
+      if (isNaN(perPage)) {
+        perPage = 50
+      }
+      searchCondition.perPage = perPage
+    }
   }
   const { repositories, totalCount } = await getRepositories(searchCondition)
   return {
@@ -78,6 +88,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       language,
       sort,
       page,
+      perPage
     },
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,19 +52,16 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   let sort: SortOption['value'] = 'stars'
   let page = 1
   if (Object.keys(context.query).length > 0) {
-    // language
     if (context.query.language !== '' && typeof context.query.language == 'string') {
       searchCondition.language = context.query.language
       language =
         languageOprionts.find((option) => option.value === context.query.language)?.value ??
         'javascript'
     }
-    // sort
     if (context.query.sort !== '' && typeof context.query.sort == 'string') {
       sort = sortOptions.find((option) => option.value === context.query.sort)?.value ?? 'stars'
       searchCondition.sort = sort
     }
-    // page
     if (context.query.page !== '' && typeof context.query.page == 'string') {
       page = Number(context.query.page)
       if (isNaN(page)) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import RepositorySearchForm, {
   languageOprionts,
   sortOptions,
 } from '../Components/repositorySearchForm'
-import { GitHubRepository, getRepositories } from './api/githubApi'
+import { GitHubRepository, getRepositories, GitHubRepositorySearch } from './api/githubApi'
 import HeadComp from '@/Components/head'
 import Header from '@/Components/header'
 import RepositoryCard from '@/Components/repositoryCard'
@@ -13,9 +13,10 @@ type Props = {
   repositories: GitHubRepository[]
   language: string
   sort: string
+  page: number
 }
 
-export default function Home({ repositories, language, sort }: Props) {
+export default function Home({ repositories, language, sort, page }: Props) {
   return (
     <>
       <HeadComp />
@@ -39,22 +40,34 @@ export default function Home({ repositories, language, sort }: Props) {
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const searchCondition: { language: string; sort: SortOption['value'] } = {
+  const searchCondition: GitHubRepositorySearch = {
     language: 'javascript',
     sort: 'stars',
+    page: 1,
   }
   let language = 'javascript'
   let sort: SortOption['value'] = 'stars'
+  let page = 1
   if (Object.keys(context.query).length > 0) {
+    // language
     if (context.query.language !== '' && typeof context.query.language == 'string') {
       searchCondition.language = context.query.language
       language =
         languageOprionts.find((option) => option.value === context.query.language)?.value ??
         'javascript'
     }
+    // sort
     if (context.query.sort !== '' && typeof context.query.sort == 'string') {
       sort = sortOptions.find((option) => option.value === context.query.sort)?.value ?? 'stars'
       searchCondition.sort = sort
+    }
+    // page
+    if (context.query.page !== '' && typeof context.query.page == 'string') {
+      page = Number(context.query.page)
+      if (isNaN(page)) {
+        page = 1
+      }
+      searchCondition.page = page
     }
   }
   const repositories = await getRepositories(searchCondition)
@@ -63,6 +76,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       repositories,
       language,
       sort,
+      page,
     },
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import RepositorySearchForm, {
 import { GitHubRepository, getRepositories, GitHubRepositorySearch } from './api/githubApi'
 import HeadComp from '@/Components/head'
 import Header from '@/Components/header'
+import Pagination from '@/Components/pagination'
 import RepositoryCard from '@/Components/repositoryCard'
 
 type Props = {
@@ -14,9 +15,10 @@ type Props = {
   language: string
   sort: string
   page: number
+  totalCount: number
 }
 
-export default function Home({ repositories, language, sort, page }: Props) {
+export default function Home({ repositories, language, sort, page, totalCount }: Props) {
   return (
     <>
       <HeadComp />
@@ -34,6 +36,7 @@ export default function Home({ repositories, language, sort, page }: Props) {
             <h1>NO Data or API Error. Please wait </h1>
           )}
         </div>
+        <Pagination currentPage={page} totalCount={totalCount} perPage={50} />
       </main>
     </>
   )
@@ -70,10 +73,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       searchCondition.page = page
     }
   }
-  const repositories = await getRepositories(searchCondition)
+  const { repositories, totalCount } = await getRepositories(searchCondition)
   return {
     props: {
       repositories,
+      totalCount,
       language,
       sort,
       page,

--- a/test.http
+++ b/test.http
@@ -16,6 +16,7 @@ X-GitHub-Api-Version: 2022-11-28
 #stargazers_count
 #watchers_count
 #forks_count
+# total_count
 
 ### Response Sample
 #{


### PR DESCRIPTION
## 関連チケット
#6 

## 概要
- クエリパラムに応じたページング処理を追加
- Paginationコンポーネントをフロントエンドに追加
- バックエンドでページに応じたapi通信に変更

## 動作確認方法
どのような動作確認が必要か書いてください。
- Paginationのtestコードを追加

## フロントエンド
ページネーションのパターンは4種類あります。

1
- トータルのページ数が6ページ以下の場合は全てのページ遷移のボタンを表示する
<img width="172" alt="image" src="https://github.com/ysknsid25/booby/assets/79493776/e3f2800f-4ee5-4b08-bce6-715d852fa092">

2
- トータルのページ数が7ページ以上あり、現在のページ番号が3以下の場合以下の画像のように表示する。
<img width="163" alt="image" src="https://github.com/ysknsid25/booby/assets/79493776/f42a8011-7ef0-497c-b263-e0cccb256e42">

3
- トータルのページ数が7ページ以上あり、現在のページがトータルページ数 - 2以上の場合に以下の画像のように表示する。
<img width="169" alt="image" src="https://github.com/ysknsid25/booby/assets/79493776/f6c7ee45-c3e6-4cc3-a2e1-a1a41d9521f1">

4
- トータルのページ数が7ページ以上あり、2と3のパターンに当てはまらない場合に以下の画像のように表示する。
<img width="214" alt="image" src="https://github.com/ysknsid25/booby/assets/79493776/c6ce1162-61b9-49ad-afd3-57dbd1891c09">


## 気になっているところ/補足
自信のないところや特にレビューしてほしいところ、その他補足したいことがあれば記載してください。










